### PR TITLE
Use --platform browser in tsup

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:plugin": "tsup src/itk.plugin.ts --outDir dist",
-    "build:viewer": "tsup src/viewer.tsx --outDir dist --tsconfig tsconfig.react.json",
+    "build:plugin": "tsup src/itk.plugin.ts --outDir dist --platform browser",
+    "build:viewer": "tsup src/viewer.tsx --outDir dist --tsconfig tsconfig.react.json --platform browser",
     "build": "npm run build:plugin && npm run build:viewer",
     "dev": "tsup --watch "
   },


### PR DESCRIPTION
This ensures we get the correct package.json exports conditions

Which is passed to esbuild

  https://esbuild.github.io/api/#platform

to get the correct conditions for the browser:

  https://nodejs.org/api/packages.html#resolving-user-conditions

The default for tsup is node.

@PaulHax @stevejpurves 